### PR TITLE
Security api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SPACE_USER="robertjauregui00@outlook.com"
+SPACE_PASSWORD="JSCHackPassTest!"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/_build/doctrees
+docs/_build/html
+docs/_build/latex
+docs/_build/man
+docs/_build/texinfo
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# Go build artifacts
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Go workspace
+bin/
+pkg/

--- a/tle.py
+++ b/tle.py
@@ -1,10 +1,15 @@
 import requests
-import json
+import json 
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# import credentials from .env
+username = os.getenv('SPACE_USER')
+password = os.getenv('SPACE_PASSWORD')
 
 def fetch_tles():
     # Space-Track credentials
-    username = "robertjauregui00@outlook.com"
-    password = "JSCHackPassTest!"
     url = "https://www.space-track.org/ajaxauth/login"
     query = "https://www.space-track.org/basicspacedata/query/class/tle_latest/ORDINAL/1/DECAYED/false/PERIOD/<128/format/json"
 


### PR DESCRIPTION
Congrats at the JSC Hackathon! 

I added some security fixes for your API key addition from Space-Track. It's a good idea to keep your credentials in a hidden .env file, which can be accessed using dotenv through a proxy variable. 

I moved the credentials to a .env.example file and added the dotenv import of the credentials to the tle.py file. I also included .env in a .gitignore file to ensure it's kept hidden. Make sure to rename the .env.example file to just .env so that .gitignore can recognize it and properly hide it. Aside from renaming to .env the rest should function fine.

Since commit history is generally permanent, I would recommend getting a fresh API key. Cool project by the way! 